### PR TITLE
Add output textbox and copy feature

### DIFF
--- a/GitExtractor/GitExtractor/MainViewModel.cs
+++ b/GitExtractor/GitExtractor/MainViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using System.Linq;
 using System.Windows;
 using OpenAI.Chat;
+using Clipboard = System.Windows.Clipboard;
 
 namespace GitExtractor
 {

--- a/GitExtractor/GitExtractor/MainViewModel.cs
+++ b/GitExtractor/GitExtractor/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Linq;
+using System.Windows;
 using OpenAI.Chat;
 
 namespace GitExtractor
@@ -46,6 +47,22 @@ namespace GitExtractor
 
         public ICommand SelectFolderCommand { get; }
         public ICommand ExtractCommand { get; }
+        public ICommand CopyOutputCommand { get; }
+
+        private string? output;
+        public string? Output
+        {
+            get => output;
+            set
+            {
+                if (output != value)
+                {
+                    output = value;
+                    OnPropertyChanged(nameof(Output));
+                    CommandManager.InvalidateRequerySuggested();
+                }
+            }
+        }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -53,6 +70,7 @@ namespace GitExtractor
         {
             SelectFolderCommand = new RelayCommand(_ => SelectFolder());
             ExtractCommand = new RelayCommand(_ => Extract());
+            CopyOutputCommand = new RelayCommand(_ => CopyOutput(), _ => !string.IsNullOrEmpty(Output));
             LoadSettings();
         }
 
@@ -104,12 +122,11 @@ namespace GitExtractor
                 ChatClient client = new("gpt-4o", ApiKey);
                 string prompt = "Analyze the following git diff files and provide your insights:\n\n. this is for a weekly report. please keep it short and understandable, even for developers who are not involved in the project. write in bullet points. add a header for each branch contained in the diffs and write down the bullet points below. be minimalistic, only 1 to 2 sentences per change. you may summarize several diffs if it is a more global change. unimportant diffs may also be ignored." + diffText;
                 ChatCompletion completion = client.CompleteChat(prompt);
-                string response = completion.Content.FirstOrDefault()?.Text ?? "No response";
-                System.Windows.MessageBox.Show(response, "OpenAI Analysis");
+                Output = completion.Content.FirstOrDefault()?.Text ?? "No response";
             }
             catch (Exception ex)
             {
-                System.Windows.MessageBox.Show($"Failed to call OpenAI API: {ex.Message}");
+                Output = $"Failed to call OpenAI API: {ex.Message}";
             }
         }
 
@@ -159,6 +176,14 @@ namespace GitExtractor
             catch
             {
                 // ignore errors when saving settings
+            }
+        }
+
+        private void CopyOutput()
+        {
+            if (!string.IsNullOrEmpty(Output))
+            {
+                Clipboard.SetText(Output);
             }
         }
 

--- a/GitExtractor/GitExtractor/MainWindow.xaml
+++ b/GitExtractor/GitExtractor/MainWindow.xaml
@@ -17,6 +17,8 @@
                 <DatePicker SelectedDate="{Binding SelectedWeek}" Margin="5,0,0,0"/>
             </StackPanel>
             <Button Content="Extract" Width="100" HorizontalAlignment="Left" Command="{Binding ExtractCommand}"/>
+            <TextBox Text="{Binding Output}" Margin="0,10,0,0" Height="200" AcceptsReturn="True" TextWrapping="Wrap" IsReadOnly="True"/>
+            <Button Content="Copy Output" Width="100" HorizontalAlignment="Left" Command="{Binding CopyOutputCommand}" Margin="0,5,0,0"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add Output property and copy command in MainViewModel
- show LLM response in a textbox with a copy button in MainWindow

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build GitExtractor.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe3b3eec88333951f3ea38b87b21d