### PR TITLE
Integrate ModernWpf styles

### DIFF
--- a/GitExtractor/GitExtractor/App.xaml
+++ b/GitExtractor/GitExtractor/App.xaml
@@ -1,9 +1,15 @@
-﻿<Application x:Class="GitExtractor.App"
+<Application x:Class="GitExtractor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GitExtractor"
+             xmlns:ui="http://schemas.modernwpf.com/2019"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:ThemeResources />
+                <ui:XamlControlsResources />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/GitExtractor/GitExtractor/MainWindow.xaml
+++ b/GitExtractor/GitExtractor/MainWindow.xaml
@@ -4,21 +4,34 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:GitExtractor"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        ui:WindowHelper.UseModernWindowStyle="True"
+        Title="GitExtractor" Height="450" Width="800">
     <Grid Margin="10">
-        <StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+        <ui:SimpleStackPanel Spacing="12">
+            <ui:SimpleStackPanel Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
                 <TextBox Text="{Binding FolderPath}" Width="300" IsReadOnly="True" Margin="0,0,5,0"/>
-                <Button Content="Select Folder" Command="{Binding SelectFolderCommand}"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                <Button Content="Select Folder"
+                        Command="{Binding SelectFolderCommand}"
+                        Style="{StaticResource AccentButtonStyle}"/>
+            </ui:SimpleStackPanel>
+            <ui:SimpleStackPanel Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
                 <Label Content="Week" VerticalAlignment="Center"/>
                 <DatePicker SelectedDate="{Binding SelectedWeek}" Margin="5,0,0,0"/>
-            </StackPanel>
-            <Button Content="Extract" Width="100" HorizontalAlignment="Left" Command="{Binding ExtractCommand}"/>
+            </ui:SimpleStackPanel>
+            <Button Content="Extract"
+                    Width="100"
+                    HorizontalAlignment="Left"
+                    Command="{Binding ExtractCommand}"
+                    Style="{StaticResource AccentButtonStyle}"/>
             <TextBox Text="{Binding Output}" Margin="0,10,0,0" Height="200" AcceptsReturn="True" TextWrapping="Wrap" IsReadOnly="True"/>
-            <Button Content="Copy Output" Width="100" HorizontalAlignment="Left" Command="{Binding CopyOutputCommand}" Margin="0,5,0,0"/>
-        </StackPanel>
+            <Button Content="Copy Output"
+                    Width="100"
+                    HorizontalAlignment="Left"
+                    Command="{Binding CopyOutputCommand}"
+                    Margin="0,5,0,0"
+                    Style="{StaticResource AccentButtonStyle}"/>
+        </ui:SimpleStackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add ModernWPF resource dictionaries
- enable modern window style via WindowHelper
- switch to SimpleStackPanel controls for modern layout
- style buttons with `AccentButtonStyle`

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build GitExtractor.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fefdb0e308333bf0d1ecd9b76d6e9